### PR TITLE
Enhance Markdown list handling in double split logic

### DIFF
--- a/src/pages/compare/diff-review.tsx
+++ b/src/pages/compare/diff-review.tsx
@@ -47,19 +47,18 @@ export default function CompareContent({ l10nedEntry, sourceEntry, locale, split
                 {Array.from({ length: maxLength }).flatMap((_, i) => {
                     const isMarkdownListItem = (line: string) => line.trimStart().startsWith('- ');
 
+                    const currentIsMarkdown = isMarkdownListItem(l10nedLines[i] || '') || isMarkdownListItem(sourceLines[i] || '');
+                    const nextIsMarkdown = i + 1 < maxLength && (isMarkdownListItem(l10nedLines[i + 1] || '') || isMarkdownListItem(sourceLines[i + 1] || ''));
+
                     return [
                         <div
                             key={i}
-                            className={`flex rounded px-4 py-1 font-mono break-all whitespace-pre-wrap hover:bg-gray-200 dark:hover:bg-gray-700 ${
-                                isMarkdownListItem(l10nedLines[i] || '') || isMarkdownListItem(sourceLines[i] || '')
-                                    ? 'mb-0'
-                                    : ''
-                            }`}
+                            className={`flex rounded px-4 py-1 font-mono break-all whitespace-pre-wrap hover:bg-gray-200 dark:hover:bg-gray-700`}
                         >
                             <div className="mr-4 w-1/2">{l10nedLines[i] || <>&nbsp;</>}</div>
                             <div className="w-1/2">{sourceLines[i] || <>&nbsp;</>}</div>
                         </div>,
-                        splitMethod === 'double' && i < maxLength - 1 && !isMarkdownListItem(l10nedLines[i] || '')
+                        splitMethod === 'double' && i < maxLength - 1 && (!currentIsMarkdown || !nextIsMarkdown)
                             ? <div key={`spacer-${i}`} className="h-4" />
                             : null,
                     ];

--- a/src/pages/compare/diff-review.tsx
+++ b/src/pages/compare/diff-review.tsx
@@ -18,19 +18,11 @@ export default function CompareContent({ l10nedEntry, sourceEntry, locale, split
     const processMarkdownList = (content: string) => {
         return content
             .split(splitter)
-            .reduce((acc: string[], line: string) => {
-                const trimmedLine = line.trimStart();
-                if (trimmedLine.startsWith('- ')) {
-                    if (acc.length > 0 && acc[acc.length - 1].trimStart().startsWith('- ')) {
-                        acc[acc.length - 1] += ` ${trimmedLine.slice(2)}`;
-                    } else {
-                        acc.push(trimmedLine);
-                    }
-                } else {
-                    acc.push(line);
-                }
-                return acc;
-            }, []);
+            .flatMap((block) => {
+                return block
+                    .split(/\n(?=\s*- )/)
+                    .map((line) => line.trimStart());
+            });
     };
 
     const l10nedLines = processMarkdownList(l10nedEntry.content);

--- a/src/pages/compare/diff-review.tsx
+++ b/src/pages/compare/diff-review.tsx
@@ -6,9 +6,10 @@ interface DiffReviewProps {
     locale: string;
     splitMethod: 'double' | 'single';
     path: string | null;
+    enableMarkdownProcessing: boolean;
 }
 
-export default function CompareContent({ l10nedEntry, sourceEntry, locale, splitMethod, path }: DiffReviewProps) {
+export default function CompareContent({ l10nedEntry, sourceEntry, locale, splitMethod, path, enableMarkdownProcessing }: DiffReviewProps) {
     if (!l10nedEntry || !sourceEntry) {
         return <div>Entries are not available for comparison.</div>;
     }
@@ -16,6 +17,9 @@ export default function CompareContent({ l10nedEntry, sourceEntry, locale, split
     let splitter: string = splitMethod === 'single' ? '\n' : '\n\n';
 
     const processMarkdownList = (content: string) => {
+        if (!enableMarkdownProcessing) {
+            return content.split(splitter);
+        }
         return content
             .split(splitter)
             .flatMap((block) => {

--- a/src/pages/compare/diff-review.tsx
+++ b/src/pages/compare/diff-review.tsx
@@ -44,16 +44,26 @@ export default function CompareContent({ l10nedEntry, sourceEntry, locale, split
                 </div>
             </section>
             <section>
-                {Array.from({ length: maxLength }).flatMap((_, i) => [
-                    <div
-                        key={i}
-                        className="flex rounded px-4 py-1 font-mono break-all whitespace-pre-wrap hover:bg-gray-200 dark:hover:bg-gray-700"
-                    >
-                        <div className="mr-4 w-1/2">{l10nedLines[i] || <>&nbsp;</>}</div>
-                        <div className="w-1/2">{sourceLines[i] || <>&nbsp;</>}</div>
-                    </div>,
-                    splitMethod === 'double' && i < maxLength - 1 ? <div key={`spacer-${i}`} className="h-4" /> : null,
-                ])}
+                {Array.from({ length: maxLength }).flatMap((_, i) => {
+                    const isMarkdownListItem = (line: string) => line.trimStart().startsWith('- ');
+
+                    return [
+                        <div
+                            key={i}
+                            className={`flex rounded px-4 py-1 font-mono break-all whitespace-pre-wrap hover:bg-gray-200 dark:hover:bg-gray-700 ${
+                                isMarkdownListItem(l10nedLines[i] || '') || isMarkdownListItem(sourceLines[i] || '')
+                                    ? 'mb-0'
+                                    : ''
+                            }`}
+                        >
+                            <div className="mr-4 w-1/2">{l10nedLines[i] || <>&nbsp;</>}</div>
+                            <div className="w-1/2">{sourceLines[i] || <>&nbsp;</>}</div>
+                        </div>,
+                        splitMethod === 'double' && i < maxLength - 1 && !isMarkdownListItem(l10nedLines[i] || '')
+                            ? <div key={`spacer-${i}`} className="h-4" />
+                            : null,
+                    ];
+                })}
             </section>
         </>
     );

--- a/src/pages/compare/diff-review.tsx
+++ b/src/pages/compare/diff-review.tsx
@@ -15,8 +15,26 @@ export default function CompareContent({ l10nedEntry, sourceEntry, locale, split
 
     let splitter: string = splitMethod === 'single' ? '\n' : '\n\n';
 
-    const l10nedLines = l10nedEntry.content.split(splitter);
-    const sourceLines = sourceEntry.content.split(splitter);
+    const processMarkdownList = (content: string) => {
+        return content
+            .split(splitter)
+            .reduce((acc: string[], line: string) => {
+                const trimmedLine = line.trimStart();
+                if (trimmedLine.startsWith('- ')) {
+                    if (acc.length > 0 && acc[acc.length - 1].trimStart().startsWith('- ')) {
+                        acc[acc.length - 1] += ` ${trimmedLine.slice(2)}`;
+                    } else {
+                        acc.push(trimmedLine);
+                    }
+                } else {
+                    acc.push(line);
+                }
+                return acc;
+            }, []);
+    };
+
+    const l10nedLines = processMarkdownList(l10nedEntry.content);
+    const sourceLines = processMarkdownList(sourceEntry.content);
     const maxLength = Math.max(l10nedLines.length, sourceLines.length);
 
     return (

--- a/src/pages/compare/diff-review.tsx
+++ b/src/pages/compare/diff-review.tsx
@@ -21,7 +21,7 @@ export default function CompareContent({ l10nedEntry, sourceEntry, locale, split
             .flatMap((block) => {
                 return block
                     .split(/\n(?=\s*- )/)
-                    .map((line) => line.trimStart());
+                    .map((line) => line);
             });
     };
 

--- a/src/pages/compare/diff-review.tsx
+++ b/src/pages/compare/diff-review.tsx
@@ -45,7 +45,7 @@ export default function CompareContent({ l10nedEntry, sourceEntry, locale, split
             </section>
             <section>
                 {Array.from({ length: maxLength }).flatMap((_, i) => {
-                    const isMarkdownListItem = (line: string) => line.trimStart().startsWith('- ');
+                    const isMarkdownListItem = (line: string) => line.trim().startsWith('- ');
 
                     const currentIsMarkdown = isMarkdownListItem(l10nedLines[i] || '') || isMarkdownListItem(sourceLines[i] || '');
                     const nextIsMarkdown = i + 1 < maxLength && (isMarkdownListItem(l10nedLines[i + 1] || '') || isMarkdownListItem(sourceLines[i + 1] || ''));

--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -180,12 +180,12 @@ export default function ComparePage() {
                     <option value="single">Split Method: Single(\n)</option>
                 </select>
                 {splitMethod === 'double' && (
-                    <label className="flex items-center space-x-2">
+                    <label className="flex items-center space-x-2 rounded border-2 border-amber-400 bg-transparent px-4 py-1.5 hover:bg-amber-100 dark:hover:bg-amber-900">
                         <input
                             type="checkbox"
                             checked={enableMarkdownProcessing}
                             onChange={(e) => setEnableMarkdownProcessing(e.target.checked)}
-                            className="rounded border-amber-400 bg-transparent hover:bg-amber-100 dark:hover:bg-amber-900"
+                            className="mr-2"
                         />
                         <span>Enable Markdown Processing (Special handling for list items starting with '- ')</span>
                     </label>

--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -187,7 +187,7 @@ export default function ComparePage() {
                             onChange={(e) => setEnableMarkdownProcessing(e.target.checked)}
                             className="mr-2"
                         />
-                        <span>Enable Markdown Processing (Special handling for list items starting with '- ')</span>
+                        <span>Split MD List</span>
                     </label>
                 )}
             </div>

--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -200,6 +200,7 @@ export default function ComparePage() {
                     locale={locale}
                     splitMethod={splitMethod}
                     path={path}
+                    enableMarkdownProcessing={enableMarkdownProcessing}
                 />
             )}
 

--- a/src/pages/compare/index.tsx
+++ b/src/pages/compare/index.tsx
@@ -20,7 +20,8 @@ export default function ComparePage() {
         [l10nedEntry, setL10nedEntry] = useState<Entry | null | undefined>(),
         [sourceEntry, setSourceEntry] = useState<Entry | null | undefined>(),
         [loading, setLoading] = useState(false),
-        [splitMethod, setSplitMethod] = useState<'double' | 'single'>('double');
+        [splitMethod, setSplitMethod] = useState<'double' | 'single'>('double'),
+        [enableMarkdownProcessing, setEnableMarkdownProcessing] = useState(true);
 
     const { setMessage } = useContext(BannerContext);
     const { preferences } = usePreferences();
@@ -178,6 +179,17 @@ export default function ComparePage() {
                     <option value="double">Split Method: Double(\n\n)</option>
                     <option value="single">Split Method: Single(\n)</option>
                 </select>
+                {splitMethod === 'double' && (
+                    <label className="flex items-center space-x-2">
+                        <input
+                            type="checkbox"
+                            checked={enableMarkdownProcessing}
+                            onChange={(e) => setEnableMarkdownProcessing(e.target.checked)}
+                            className="rounded border-amber-400 bg-transparent hover:bg-amber-100 dark:hover:bg-amber-900"
+                        />
+                        <span>Enable Markdown Processing (Special handling for list items starting with '- ')</span>
+                    </label>
+                )}
             </div>
 
             {l10nedEntry && sourceEntry && locale && (


### PR DESCRIPTION
- Updated the double split logic to handle Markdown list items starting with '- ' more effectively.
- Added support for ignoring leading spaces or tabs before '- ' to ensure proper processing of Markdown list items.
- Improved content splitting and merging for better Markdown compatibility.